### PR TITLE
chore(readme): Delete advanced noirup usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,3 @@ Replace `NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX` with the version from the o
 ```bash
 aztec-cli get-node-info
 ```
-
-For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/installation/other_install_methods)


### PR DESCRIPTION
First noticed the link is broken, then figured Aztec.nr users likely don't need to learn the different ways of using noirup https://noir-lang.org/docs/getting_started/noir_installation.

Hence deleting the line.