### PR TITLE
 Fix Typos in `scheduled_delay_change.nr` and `subarray.nr`

### DIFF
--- a/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
+++ b/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
@@ -5,7 +5,7 @@ mod test;
 
 // This data structure is used by SharedMutable to store the minimum delay with which a ScheduledValueChange object can
 // schedule a change.
-// This delay is initally equal to INITIAL_DELAY, and can be safely mutated to any other value over time. This mutation
+// This delay is initially equal to INITIAL_DELAY, and can be safely mutated to any other value over time. This mutation
 // is performed via `schedule_change` in order to satisfy ScheduleValueChange constraints: if e.g. we allowed for the
 // delay to be decreased immediately then it'd be possible for the state variable to schedule a value change with a
 // reduced delay, invalidating prior private reads.

--- a/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
+++ b/aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr
@@ -58,7 +58,7 @@ impl<let INITIAL_DELAY: u32> ScheduledDelayChange<INITIAL_DELAY> {
         // When changing the delay value we must ensure that it is not possible to produce a value change with a delay
         // shorter than the current one.
         let blocks_until_change = if new > current {
-            // Increasing the delay value can therefore be done immediately: this does not invalidate prior contraints
+            // Increasing the delay value can therefore be done immediately: this does not invalidate prior constraints
             // about how quickly a value might be changed (indeed it strengthens them).
             0
         } else {

--- a/aztec/src/utils/array/subarray.nr
+++ b/aztec/src/utils/array/subarray.nr
@@ -25,7 +25,7 @@ mod test {
 
     #[test]
     unconstrained fn subarray_into_empty() {
-        // In all of these cases we're setting DST_LEN to be 0, so we always get back an emtpy array.
+        // In all of these cases we're setting DST_LEN to be 0, so we always get back an empty array.
         assert_eq(subarray([], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 2), []);


### PR DESCRIPTION
## **Description**
This pull request fixes typos in the following files:

1. **File:** `aztec/src/state_vars/shared_mutable/scheduled_delay_change.nr`
   - **Fixes:**
     - Corrected "initally" to "initially" in the description of `ScheduledValueChange` (Line 5).
     - Corrected "contraints" to "constraints" in a comment within the `schedule_change` method (Line 58).

2. **File:** `aztec/src/utils/array/subarray.nr`
   - **Fixes:**
     - Corrected "emtpy" to "empty" in a test case description (Line 25).