### PR TITLE
Fix/err

### DIFF
--- a/authwit/src/auth.nr
+++ b/authwit/src/auth.nr
@@ -10,7 +10,7 @@ use dep::aztec::protocol_types::{
 };
 
 /**
- * Authenticaion witness helper library
+ * Authentication witness helper library
  *
  * Authentication Witness is a scheme for authenticating actions on Aztec, so users can allow third-parties
  * (e.g. protocols or other users) to execute an action on their behalf.

--- a/aztec/src/context/globals/public_global_variables.nr
+++ b/aztec/src/context/globals/public_global_variables.nr
@@ -1,2 +1,2 @@
-// protocl global vars are equal to the private ones so we just re-export them here under a different name
+// protocol global vars are equal to the private ones so we just re-export them here under a different name
 pub use dep::protocol_types::abis::global_variables::GlobalVariables as PublicGlobalVariables;

--- a/aztec/src/utils/array/collapse.nr
+++ b/aztec/src/utils/array/collapse.nr
@@ -9,7 +9,7 @@ pub fn collapse<T, let N: u32>(input: [Option<T>; N]) -> BoundedVec<T, N>
 where
     T: Eq,
 {
-    // Computing the collpased BoundedVec would result in a very large number of constraints, since we'd need to loop
+    // Computing the collapsed BoundedVec would result in a very large number of constraints, since we'd need to loop
     // over the input array and conditionally write to a dynamic vec index, which is a very unfriendly pattern to the
     // proving backend.
     // Instead, we use an unconstrained function to produce the final collapsed array, along with some hints, and then

--- a/aztec/src/utils/array/subarray.nr
+++ b/aztec/src/utils/array/subarray.nr
@@ -25,7 +25,7 @@ mod test {
 
     #[test]
     unconstrained fn subarray_into_empty() {
-        // In all of these cases we're setting DST_LEN to be 0, so we always get back an emtpy array.
+        // In all of these cases we're setting DST_LEN to be 0, so we always get back an empty array.
         assert_eq(subarray([], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 2), []);


### PR DESCRIPTION
# Fix: Corrected typos in multiple source files

## What was changed
1. **Corrected typos**:
   - Replaced `emtpy` with `empty` in `aztec/src/utils/array/subarray.nr:28`.
   - Replaced `collpased` with `collapsed` in `aztec/src/utils/array/collapse.nr:12`.
   - Replaced `protocl` with `protocol` in `aztec/src/context/globals/public_global_variables.nr:1`.
   - Replaced `Authenticaion` with `Authentication` in `authwit/src/auth.nr:13`.

## Why these changes were made
- **Fixing typos** ensures the clarity, professionalism, and accuracy of the codebase.
- Correct terminology avoids potential confusion for developers and readers.

## Additional Notes
- These changes focus solely on fixing typographical errors and do not affect functionality.
