### PR TITLE
fix: Incorrect macro usage and redundant boolean comparison

### DIFF
--- a/authwit/src/account.nr
+++ b/authwit/src/account.nr
@@ -42,7 +42,7 @@ impl AccountActions<&mut PrivateContext> {
             [app_payload.hash(), fee_payload.hash()],
             GENERATOR_INDEX__COMBINED_PAYLOAD,
         );
-        assert(valid_fn(self.context, combined_payload_hash));
+        assert!(valid_fn(self.context, combined_payload_hash));
 
         fee_payload.execute_calls(self.context);
         self.context.end_setup();
@@ -77,7 +77,7 @@ impl AccountActions<&mut PrivateContext> {
             inner_hash,
         );
         let valid_fn = self.is_valid_impl;
-        assert(valid_fn(self.context, message_hash) == true, "Message not authorized by account");
+        assert!(valid_fn(self.context, message_hash), "Message not authorized by account");
         IS_VALID_SELECTOR
     }
     // docs:end:verify_private_authwit


### PR DESCRIPTION
In Rust, `assert!` is a macro and must be called with an exclamation mark and a condition inside the parentheses. Using `assert(condition)` without the exclamation mark will result in a compilation error, as `assert` does not exist as a function. Without fixing this, the program will not compile.

Redundant `== true` Check: The function `valid_fn` already returns a boolean value (`bool`). When a function already returns a boolean value (`bool`), an additional comparison with `true` or `false` is redundant and reduces code readability.










