### PR TITLE
Fix Typo in `subarray.nr`

### DIFF
--- a/aztec/src/utils/array/subarray.nr
+++ b/aztec/src/utils/array/subarray.nr
@@ -25,7 +25,7 @@ mod test {
 
     #[test]
     unconstrained fn subarray_into_empty() {
-        // In all of these cases we're setting DST_LEN to be 0, so we always get back an emtpy array.
+        // In all of these cases we're setting DST_LEN to be 0, so we always get back an empty array.
         assert_eq(subarray([], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 2), []);


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `subarray.nr`

## Description
Corrected a typo in the `subarray.nr` file to improve documentation clarity.

### Changes Made:
- **File Modified:** `aztec/src/utils/array/subarray.nr`
- **Summary of Changes:**  
  - Line 25: Corrected the word "emtpy" to "empty" in the comment for clarity.

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] The change follows the project's [contributing guidelines](link-to-contributing-guidelines).
- [x] Documentation is now clear and correct.
- [x] No code functionality is impacted by this change.

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment update only)

## Additional Notes
<!-- Add any additional comments for reviewers. -->
This is a minor typo fix in the documentation within the code. Please review to ensure no other similar typos are present.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
