### PR TITLE
Typo fix in public_global_variables.n

### DIFF
--- a/aztec/src/context/globals/public_global_variables.nr
+++ b/aztec/src/context/globals/public_global_variables.nr
@@ -1,2 +1,2 @@
-// protocl global vars are equal to the private ones so we just re-export them here under a different name
+// protocol global vars are equal to the private ones so we just re-export them here under a different name
 pub use dep::protocol_types::abis::global_variables::GlobalVariables as PublicGlobalVariables;


### PR DESCRIPTION
# Pull Request Title: Typo fix in public_global_variables.nr

## Description:
This pull request addresses a typo in the `public_global_variables.nr` file. The comment has been updated to correctly reflect the intended terminology.

## Changes:
- Fixed a typo in the comment: changed "protocl" to "protocol".
- The comment now reads: `// protocol global vars are equal to the private ones so we just re-export them here under a different name`.

## File(s) Modified:
- `aztec/src/context/globals/public_global_variables.nr`

## Reasoning:
Correcting the typo ensures that the comments align with the rest of the codebase and enhances readability.

## Checklist:
- [x] The code follows the project's coding guidelines.
- [x] All relevant tests are passing.
- [x] I have updated the documentation (if necessary).
- [x] I have tested the changes locally.

## Related Issues:
N/A

## Additional Notes:
N/A
