### PR TITLE
chore: fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ Replace `NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX` with the version from the o
 aztec-cli get-node-info
 ```
 
-For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/installation/other_install_methods)
+For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/quick_start)


### PR DESCRIPTION
- [Noir's getting started.](https://noir-lang.org/docs/getting_started/installation/other_install_methods)  <!-- The old link points to an outdated installation methods page. -->
+ [Noir's getting started.](https://noir-lang.org/docs/getting_started/quick_start)  <!-- The new link points to the current quick start guide. -->
