### PR TITLE
Fix syntax errors across multiple files

### DIFF
--- a/authwit/src/auth.nr
+++ b/authwit/src/auth.nr
@@ -10,7 +10,7 @@ use dep::aztec::protocol_types::{
 };
 
 /**
- * Authenticaion witness helper library
+ * Authentication witness helper library
  *
  * Authentication Witness is a scheme for authenticating actions on Aztec, so users can allow third-parties
  * (e.g. protocols or other users) to execute an action on their behalf.

--- a/aztec/src/context/globals/public_global_variables.nr
+++ b/aztec/src/context/globals/public_global_variables.nr
@@ -1,2 +1,2 @@
-// protocl global vars are equal to the private ones so we just re-export them here under a different name
+// protocol global vars are equal to the private ones so we just re-export them here under a different name
 pub use dep::protocol_types::abis::global_variables::GlobalVariables as PublicGlobalVariables;

--- a/aztec/src/oracle/note_discovery.nr
+++ b/aztec/src/oracle/note_discovery.nr
@@ -13,7 +13,7 @@ use dep::protocol_types::address::AztecAddress;
 /// `recipient` is the account to which the note was sent to. Other accounts will not be able to access this note (e.g.
 /// other accounts will not be able to see one another's token balance notes, even in the same PXE) unless authorized.
 ///
-/// Returns true if the note was sucessfully delivered and added to PXE's database.
+/// Returns true if the note was successfully delivered and added to PXE's database.
 pub unconstrained fn deliver_note(
     contract_address: AztecAddress,
     storage_slot: Field,

--- a/aztec/src/pxe_db/mod.nr
+++ b/aztec/src/pxe_db/mod.nr
@@ -18,7 +18,7 @@ where
 {
     /// Returns a DBArray connected to a contact's PXE database at a base database slot. Array elements are be stored at
     /// contiguous slots following the base slot, so there should be sufficient space between array base slots to
-    /// accomodate elements. A reasonable strategy is to make the base slot a hash of a unique value.
+    /// accommodate elements. A reasonable strategy is to make the base slot a hash of a unique value.
     pub unconstrained fn at(contract_address: AztecAddress, base_slot: Field) -> Self {
         Self { contract_address, base_slot }
     }

--- a/aztec/src/pxe_db/mod.nr
+++ b/aztec/src/pxe_db/mod.nr
@@ -58,7 +58,7 @@ where
         // array past the removed element one slot backward so that we don't end up with a gap and preserve the
         // contiguous slots. We can skip this when deleting the last element however.
         if index != current_length - 1 {
-            // The souce and destination regions overlap, but `copy` supports this.
+            // The source and destination regions overlap, but `copy` supports this.
             pxe_db::copy(
                 self.contract_address,
                 self.slot_at(index + 1),

--- a/aztec/src/utils/array/subarray.nr
+++ b/aztec/src/utils/array/subarray.nr
@@ -27,7 +27,7 @@ mod test {
 
     #[test]
     unconstrained fn subarray_into_empty() {
-        // In all of these cases we're setting DST_LEN to be 0, so we always get back an emtpy array.
+        // In all of these cases we're setting DST_LEN to be 0, so we always get back an empty array.
         assert_eq(subarray::<Field, _, _>([], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 0), []);
         assert_eq(subarray([1, 2, 3, 4, 5], 2), []);

--- a/aztec/src/utils/array/subbvec.nr
+++ b/aztec/src/utils/array/subbvec.nr
@@ -77,7 +77,7 @@ mod test {
     unconstrained fn subbvec_dst_len_causes_enlarge() {
         let bvec = BoundedVec::<_, 10>::from_array([1, 2, 3, 4, 5]);
 
-        // subbvec does not supprt capacity increases
+        // subbvec does not support capacity increases
         let _: BoundedVec<_, 11> = subbvec(bvec, 0);
     }
 


### PR DESCRIPTION
- In `auth.nr`, "Authenticaion" was corrected to "Authentication".
- In `public_global_variables.nr`, "protocl" was corrected to "protocol".
- In `note_discovery.nr`, "sucessfully" was corrected to "successfully".
- In `mod.nr` (multiple occurrences), "accomodate" was corrected to "accommodate", and other minor errors were fixed for consistency.
- In `subarray.nr`, "emtpy" was corrected to "empty".
- In `subbvec.nr`, "supprt" was corrected to "support".
